### PR TITLE
here's an actual change for you - fixed gbm.cverr() max.time bug

### DIFF
--- a/R/gbm_cverr.R
+++ b/R/gbm_cverr.R
@@ -376,7 +376,7 @@ gbm.cverr <- function(
     # --------------------------------------------------------------------------
     # Step 3b: Add trees as necessary and as time allows
     # --------------------------------------------------------------------------
-    tt <- as.numeric(Sys.time() - time.start)
+    tt <- as.numeric(difftime(Sys.time(), time.start, units = 'secs'))
     keep.going <- tt <= max.time
     while(all((which.min(err) >= (0.90 * length(err))), keep.going)){
       
@@ -429,7 +429,7 @@ gbm.cverr <- function(
                  length(cv.err))
       
       # Update timer
-      tt <- as.numeric(Sys.time() - time.start)
+      tt <- as.numeric(difftime(Sys.time(), time.start, units = 'secs'))
       keep.going <- tt <= max.time
     }
     


### PR DESCRIPTION
I forgot that difftime objects automatically change units when you don't explicitly tell them not to, hence the bug whenever you'd put a limit of at least 60 seconds. It would keep going past the time limit because the object monitoring the amount of time that had passed would change its units to minutes. If, for example, 61 seconds had passed, it would have a value of 1.0167 (minutes) rather than 61, so the evaluation criterion of "larger than max.time" would never be reached.